### PR TITLE
fix: show delete button in remove place from orga modal #508

### DIFF
--- a/packages/frontend/src/app/modules/admin-organisation/components/remove-place/remove-place.component.html
+++ b/packages/frontend/src/app/modules/admin-organisation/components/remove-place/remove-place.component.html
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <div class="modal-header bg-danger">
   <span id="modal-title">
     {{ "REMOVE_PLACE" | translate }}
-    <ng-container *ngIf="fromPlace">
+    <ng-container *ngIf="fromPlace && orga?.name">
       {{
         "OF_THE_ORGANIZATION" | translate : { orgaName: orga.name }
       }}</ng-container


### PR DESCRIPTION
Ajout de && orga?.name pour éviter que le template n'essaie d'accéder à une propriété undefined, ce qui empêchait l'affichage du bouton de suppression.