### PR TITLE
fix(frontend): correct typo in French privacy policy

### DIFF
--- a/packages/frontend/src/app/modules/static-pages/components/privacy-policy/privacy-policy-soliguide-fr/privacy-policy-soliguide-fr.component.html
+++ b/packages/frontend/src/app/modules/static-pages/components/privacy-policy/privacy-policy-soliguide-fr/privacy-policy-soliguide-fr.component.html
@@ -38,7 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </p>
 
     <p>
-      A ce titre, notre Politique de confidentialit&eacute; des donn&eacute;es
+      À ce titre, notre Politique de confidentialit&eacute; des donn&eacute;es
       personnelles t&eacute;moigne pr&eacute;cis&eacute;ment de notre
       <strong>
         volont&eacute; de faire respecter, au sein de Solinum, les r&egrave;gles


### PR DESCRIPTION
## Summary
- Correct orthographic typo in French privacy policy text
- Replace "A ce titre" with "À ce titre" (capitalized accented A)

## Test plan
- [ ] Verify the privacy policy page displays correctly on soliguide.fr
- [ ] Check that the text renders properly with the accented capital letter
- [ ] Confirm no other issues introduced in the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)