### PR TITLE
Bug - Liens morts suivi des email dans le menu des comptes pro

### DIFF
--- a/packages/common/src/translations/locales/ca.json
+++ b/packages/common/src/translations/locales/ca.json
@@ -2074,7 +2074,7 @@
   "TO_SEND_YOU_UPDATES": "Per permetre'ns notificar-te possibles canvis tècnics i mantenir-te informat de les noves característiques.",
   "TO_THE": "al",
   "TO_UPDATE": "Actualitza",
-  "TO_UPDATE_CAMPAIGN_BANNER": "✨Actualització dels períodes vacacionals: Comença el compte enrere ⏳!<br>Treballes en aquest centre? Dedica dos minuts a actualitzar els canvis que hi haurà al teu equipament durant el període vacacionals i assegura't que les teves portes estiguin obertes als usuaris.🚪.",
+  "TO_UPDATE_CAMPAIGN_BANNER": "✨Actualització del període vacacional: Comença el compte enrere ⏳!<br>Treballes en aquest centre? Dedica dos minuts a actualitzar els canvis que hi haurà al teu equipament durant el període vacacional i assegura't que les teves portes estiguin obertes als usuaris.🚪.",
   "TRANSLATED": "Traduït",
   "TRANSLATED_VERSION": "Versió traduïda",
   "TRANSLATE_BY": "Tradueix per",


### PR DESCRIPTION
Suppression des liens morts “modifier les emails” et “suivre les emails envoyés” et leurs clés de traduction associées